### PR TITLE
Solve the problem that FLY_D5 and FLY_D7 cannot use the soft serial port driver tmc2209

### DIFF
--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -54,11 +54,13 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint
 
 void TMC2208Stepper::begin() {
 	#if SW_CAPABLE_PLATFORM
-		beginSerial(115200);
+		#ifndef TMC2208_BAUDRATE
+			#define TMC2208_BAUDRATE 115200
+		#endif
+		beginSerial(TMC2208_BAUDRATE);
 	#endif
 	pdn_disable(true);
 	mstep_reg_select(true);
-
 }
 
 void TMC2208Stepper::defaults() {
@@ -315,6 +317,7 @@ uint32_t TMC2208Stepper::read(uint8_t addr) {
 
 	for (uint8_t i = 0; i < max_retries; i++) {
 		preReadCommunication();
+		delay(3);
 		out = _sendDatagram(datagram, len, abort_window);
 		postReadCommunication();
 

--- a/src/source/TMC2208Stepper.h
+++ b/src/source/TMC2208Stepper.h
@@ -211,7 +211,7 @@ class TMC2208Stepper : public TMCStepper {
 		static constexpr uint8_t  TMC2208_SYNC = 0x05,
 															TMC2208_SLAVE_ADDR = 0x00;
 		static constexpr uint8_t replyDelay = 2;
-		static constexpr uint8_t abort_window = 5;
+		static constexpr uint8_t abort_window = 8;
 		static constexpr uint8_t max_retries = 2;
 
 		uint64_t _sendDatagram(uint8_t [], const uint8_t, uint16_t);


### PR DESCRIPTION
Solve the problem that FLY_D5 and FLY_D7 cannot use the soft serial port driver tmc2209