### PR TITLE
SPI Bus Sharing - Redo PR 255

### DIFF
--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -78,6 +78,9 @@
 
 // Since we don't have C++20 we need to do some ugly hacks to ensure compat.
 // https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+#include <utility>
+#include <type_traits>
+
 #define __DEF_HAS_METH( methName ) \
 	template<typename T> \
 	struct ___has_##methName \

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -26,7 +26,9 @@
 
 #if defined(ARDUINO) && ARDUINO >= 100
 	#include <Arduino.h>
-	#include <SPI.h>
+	#ifndef TMC_NO_GENERIC_SPI
+		#include <SPI.h>
+	#endif
 	#include <Stream.h>
 #elif defined(bcm2835)
 	#include <bcm2835.h>
@@ -36,8 +38,12 @@
 	#if __has_include(<Arduino.h>)
 		#include <Arduino.h>
 	#endif
-	#if __has_include(<SPI.h>)
-		#include <SPI.h>
+	#ifndef TMC_NO_GENERIC_SPI
+		#if __has_include(<SPI.h>)
+			#include <SPI.h>
+		#else
+			#define TMC_NO_GENERIC_SPI
+		#endif
 	#endif
 	#if __has_include(<Stream.h>)
 		#include <Stream.h>

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -76,52 +76,7 @@
 #include "source/TMC2240_bitfields.h"
 #include "source/TMC2660_bitfields.h"
 
-// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
-// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
-#include <utility>
-#include <type_traits>
-
-#define __DEF_HAS_METH( methName ) \
-	template<typename T> \
-	struct ___has_##methName \
-	{ \
-    template<typename C> \
-    static constexpr auto test(...) -> std::false_type; \
-		template<typename C> \
-		static constexpr auto test(int) \
-		-> decltype(static_cast<void>(std::declval<C>().methName(0)), std::true_type()); \
-    using result_type       = decltype(test<T>(0)); \
-    static const bool value = result_type::value; \
-	}
-#define __HAS_METH( className, methName ) \
-	( ___has_##methName <className>::value )
-
-__DEF_HAS_METH( setMISO );
-__DEF_HAS_METH( setMOSI );
-__DEF_HAS_METH( setSCLK );
-
-#define SPI_SET_PIN_HELPER( pinDescName ) \
-	template <bool hasPin> \
-	struct _spiInitHelper_##pinDescName \
-	{}; \
-	template <> \
-	struct _spiInitHelper_##pinDescName <true> \
-	{ \
-		template <typename SPIClassT> \
-		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
-	}; \
-	template <> \
-	struct _spiInitHelper_##pinDescName <false> \
-	{ \
-		template <typename SPIClassT> \
-		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
-	}
-
-SPI_SET_PIN_HELPER( MISO );
-SPI_SET_PIN_HELPER( MOSI );
-SPI_SET_PIN_HELPER( SCLK );
-
-#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+#include "TMCStepper_fixing.h"
 
 #include "source/TMCStepperBase.h"
 #include "source/TMC2130Stepper.h"

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -76,6 +76,50 @@
 #include "source/TMC2240_bitfields.h"
 #include "source/TMC2660_bitfields.h"
 
+// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
+// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+#define __DEF_HAS_METH( methName ) \
+	template<typename T> \
+	struct ___has_##methName \
+	{ \
+    template<typename C> \
+    static constexpr auto test(...) -> std::false_type; \
+		template<typename C> \
+		static constexpr auto test(int) \
+		-> decltype(static_cast<void>(std::declval<C>().methName(0)), std::true_type()); \
+    using result_type       = decltype(test<T>(0)); \
+    static const bool value = result_type::value; \
+	}
+#define __HAS_METH( className, methName ) \
+	( ___has_##methName <className>::value )
+
+__DEF_HAS_METH( setMISO );
+__DEF_HAS_METH( setMOSI );
+__DEF_HAS_METH( setSCLK );
+
+#define SPI_SET_PIN_HELPER( pinDescName ) \
+	template <bool hasPin> \
+	struct _spiInitHelper_##pinDescName \
+	{}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <true> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
+	}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <false> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
+	}
+
+SPI_SET_PIN_HELPER( MISO );
+SPI_SET_PIN_HELPER( MOSI );
+SPI_SET_PIN_HELPER( SCLK );
+
+#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+
 #include "source/TMCStepperBase.h"
 #include "source/TMC2130Stepper.h"
 #include "source/TMC2160Stepper.h"

--- a/src/TMCStepper_SPI.h
+++ b/src/TMCStepper_SPI.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#define TMCSPI_BITORDER_LSB 0
+#define TMCSPI_BITORDER_MSB 1
+
+#define TMCSPI_CLKMODE_0    0
+#define TMCSPI_CLKMODE_1    1
+#define TMCSPI_CLKMODE_2    2
+#define TMCSPI_CLKMODE_3    3
+
+struct TMCSPIInterface {
+    virtual void begin(uint32_t maxClockFreq, int bitOrder, int clkMode) = 0;
+    virtual void end() = 0;
+    virtual uint8_t transfer(uint8_t txval) = 0;
+    virtual void sendRepeat(uint8_t val, uint16_t repcnt) = 0;
+};

--- a/src/TMCStepper_SPI.h
+++ b/src/TMCStepper_SPI.h
@@ -14,3 +14,9 @@ struct TMCSPIInterface {
     virtual uint8_t transfer(uint8_t txval) = 0;
     virtual void sendRepeat(uint8_t val, uint16_t repcnt) = 0;
 };
+
+#ifndef TMC_NO_GENERIC_SPI
+#define _TMC_SOFTSPI_DEFAULT false
+#else
+#define _TMC_SOFTSPI_DEFAULT true
+#endif

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -88,3 +88,16 @@ SPI_SET_PIN_HELPER( MOSI );
 SPI_SET_PIN_HELPER( SCLK );
 
 #define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )
+
+// Speciality of the ESP32 platform.
+#ifdef ESP_PLATFORM
+// https://github.com/espressif/arduino-esp32/blob/master/libraries/SPI/src/SPI.cpp SPIClass::begin method.
+#define SPI_BEGIN( spi, sck, miso, mosi ) ( spi.begin( sck, miso, mosi ) )
+#else
+// Other platforms.
+#define SPI_BEGIN( spi, sck, miso, mosi ) \
+	{ SPI_INIT_PIN( spi, MISO, miso ); \
+      SPI_INIT_PIN( SPI, MOSI, mosi ); \
+      SPI_INIT_PIN( SPI, SCLK, sck ); \
+	  spi.begin(); }
+#endif

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef TMC_NO_GENERIC_SPI
+
 namespace _TMC_FIXING
 {
 
@@ -101,3 +103,5 @@ SPI_SET_PIN_HELPER( SCLK );
       SPI_INIT_PIN( SPI, SCLK, sck ); \
 	  spi.begin(); }
 #endif
+
+#endif //TMC_NO_GENERIC_SPI

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -21,12 +21,16 @@ struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {
 
 // END https://en.cppreference.com/w/cpp/types/add_reference
     
-// BEGIN https://en.cppreference.com/w/cpp/utility/declval
-template<typename T> constexpr bool always_false = false;
+// BEGIN https://en.cppreference.com/w/cpp/utility/declval (inspired)
+template<typename T>
+struct always_false
+{
+	enum { value = false };
+};
  
 template<typename T>
-typename add_rvalue_reference<T>::type declval() noexcept {
-    static_assert(always_false<T>, "declval not allowed in an evaluated context");
+typename add_rvalue_reference<T>::type declval() {
+    static_assert(always_false<T>::value, "declval not allowed in an evaluated context");
 }
 
 // END https://en.cppreference.com/w/cpp/utility/declval
@@ -34,9 +38,11 @@ typename add_rvalue_reference<T>::type declval() noexcept {
 struct true_type {
     enum { value = true };
 };
-struct false_type {};
+struct false_type {
     enum { value = false };
 };
+
+} // namespace TMC_FIXING
 
 // Since we don't have C++20 we need to do some ugly hacks to ensure compat.
 // https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -1,0 +1,84 @@
+#pragma once
+
+namespace _TMC_FIXING
+{
+
+// BEGIN https://en.cppreference.com/w/cpp/types/add_reference
+namespace detail {
+ 
+template <class T>
+struct type_identity { using type = T; };
+ 
+template <class T>
+auto try_add_rvalue_reference(int) -> type_identity<T&&>;
+template <class T>
+auto try_add_rvalue_reference(...) -> type_identity<T>;
+ 
+} // namespace detail
+ 
+template <class T>
+struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {};
+
+// END https://en.cppreference.com/w/cpp/types/add_reference
+    
+// BEGIN https://en.cppreference.com/w/cpp/utility/declval
+template<typename T> constexpr bool always_false = false;
+ 
+template<typename T>
+typename add_rvalue_reference<T>::type declval() noexcept {
+    static_assert(always_false<T>, "declval not allowed in an evaluated context");
+}
+
+// END https://en.cppreference.com/w/cpp/utility/declval
+
+struct true_type {
+    enum { value = true };
+};
+struct false_type {};
+    enum { value = false };
+};
+
+// Since we don't have C++20 we need to do some ugly hacks to ensure compat.
+// https://stackoverflow.com/questions/63253287/using-sfinae-to-detect-method-with-gcc
+// Did you know that ATMEL AVR does not support standard C++ headers???
+#define __DEF_HAS_METH( methName ) \
+	template<typename T> \
+	struct ___has_##methName \
+	{ \
+    template<typename C> \
+    static constexpr auto test(...) -> _TMC_FIXING::false_type; \
+		template<typename C> \
+		static constexpr auto test(int) \
+		-> decltype(static_cast<void>(_TMC_FIXING::declval<C>().methName(0)), _TMC_FIXING::true_type()); \
+    using result_type       = decltype(test<T>(0)); \
+    static const bool value = result_type::value; \
+	}
+#define __HAS_METH( className, methName ) \
+	( ___has_##methName <className>::value )
+
+__DEF_HAS_METH( setMISO );
+__DEF_HAS_METH( setMOSI );
+__DEF_HAS_METH( setSCLK );
+
+#define SPI_SET_PIN_HELPER( pinDescName ) \
+	template <bool hasPin> \
+	struct _spiInitHelper_##pinDescName \
+	{}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <true> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{ spi.set##pinDescName( pin ); } \
+	}; \
+	template <> \
+	struct _spiInitHelper_##pinDescName <false> \
+	{ \
+		template <typename SPIClassT> \
+		static void spiSet##pinDescName( SPIClassT& spi, uint16_t pin )	{} \
+	}
+
+SPI_SET_PIN_HELPER( MISO );
+SPI_SET_PIN_HELPER( MOSI );
+SPI_SET_PIN_HELPER( SCLK );
+
+#define SPI_INIT_PIN( spi, pinDescName, val ) _spiInitHelper_##pinDescName <__HAS_METH(SPIClass, set##pinDescName)> ::spiSet##pinDescName( spi, val )

--- a/src/TMCStepper_fixing.h
+++ b/src/TMCStepper_fixing.h
@@ -7,29 +7,29 @@ namespace _TMC_FIXING
 
 // BEGIN https://en.cppreference.com/w/cpp/types/add_reference
 namespace detail {
- 
+
 template <class T>
 struct type_identity { using type = T; };
- 
+
 template <class T>
 auto try_add_rvalue_reference(int) -> type_identity<T&&>;
 template <class T>
 auto try_add_rvalue_reference(...) -> type_identity<T>;
- 
+
 } // namespace detail
- 
+
 template <class T>
 struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {};
 
 // END https://en.cppreference.com/w/cpp/types/add_reference
-    
+
 // BEGIN https://en.cppreference.com/w/cpp/utility/declval (inspired)
 template<typename T>
 struct always_false
 {
 	enum { value = false };
 };
- 
+
 template<typename T>
 typename add_rvalue_reference<T>::type declval() {
     static_assert(always_false<T>::value, "declval not allowed in an evaluated context");
@@ -104,4 +104,4 @@ SPI_SET_PIN_HELPER( SCLK );
 	  spi.begin(); }
 #endif
 
-#endif //TMC_NO_GENERIC_SPI
+#endif // TMC_NO_GENERIC_SPI

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -108,11 +108,10 @@ void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }
 }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -88,9 +88,9 @@ void TMC2130Stepper::switchCSpin(bool state) {
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -128,6 +128,7 @@ void TMC2130Stepper::beginTransaction() {
   if (_spiMan) {
     _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
   }
+#ifndef TMC_NO_GENERIC_SPI
   else if (TMC_SW_SPI == nullptr) {
     if (_has_pins)
     {
@@ -137,16 +138,19 @@ void TMC2130Stepper::beginTransaction() {
       SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }
+#endif
 }
 __attribute__((weak))
 void TMC2130Stepper::endTransaction() {
   if (_spiMan) {
     _spiMan->end();
   }
+#ifndef TMC_NO_GENERIC_SPI
   else if (TMC_SW_SPI == nullptr) {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
 }
 
 __attribute__((weak))
@@ -158,9 +162,11 @@ uint8_t TMC2130Stepper::transfer(const uint8_t data) {
   else if (TMC_SW_SPI != nullptr) {
     out = TMC_SW_SPI->transfer(data);
   }
+#ifndef TMC_NO_GENERIC_SPI
   else {
     out = SPI.transfer(data);
   }
+#endif
   return out;
 }
 

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -9,37 +9,46 @@
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
 
-TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
-  TMCStepper(RS),
-  _pinCS(pinCS),
-  link_index(link)
-  {
-    defaults();
-
-    if (link > chain_length)
-      chain_length = link;
-  }
-
-TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMCStepper(default_RS),
   _pinCS(pinCS),
+  _pinMISO(pinMISO),
+  _pinMOSI(pinMOSI),
+  _pinSCK(pinSCK),
   link_index(link)
   {
-    SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
-    TMC_SW_SPI = SW_SPI_Obj;
+    if (softSPI)
+    {
+      SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
+      TMC_SW_SPI = SW_SPI_Obj;
+    }
+    else
+    {
+      TMC_SW_SPI = nullptr;
+    }
     defaults();
 
     if (link > chain_length)
       chain_length = link;
   }
 
-TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
+TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMCStepper(RS),
   _pinCS(pinCS),
+  _pinMISO(pinMISO),
+  _pinMOSI(pinMOSI),
+  _pinSCK(pinSCK),
   link_index(link)
   {
-    SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
-    TMC_SW_SPI = SW_SPI_Obj;
+    if (softSPI)
+    {
+      SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
+      TMC_SW_SPI = SW_SPI_Obj;
+    }
+    else
+    {
+      TMC_SW_SPI = nullptr;
+    }
     defaults();
 
     if (link > chain_length)
@@ -79,6 +88,10 @@ void TMC2130Stepper::switchCSpin(bool state) {
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
+    SPI.setMISO(_pinMISO);
+    SPI.setMOSI(_pinMOSI);
+    SPI.setSCLK(_pinSCK);
+    SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }
 }
@@ -86,6 +99,7 @@ __attribute__((weak))
 void TMC2130Stepper::endTransaction() {
   if (TMC_SW_SPI == nullptr) {
     SPI.endTransaction();
+    SPI.end();
   }
 }
 

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -9,12 +9,29 @@
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
 
+TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMCStepper(RS),
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  link_index(link_index)
+  {
+    TMC_SW_SPI = nullptr;
+    defaults();
+
+    if (link_index > chain_length)
+      chain_length = link_index;
+  }
+
 TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMCStepper(default_RS),
   _pinCS(pinCS),
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   link_index(link)
   {
     if (softSPI)
@@ -38,6 +55,7 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   link_index(link)
   {
     if (softSPI)
@@ -88,9 +106,12 @@ void TMC2130Stepper::switchCSpin(bool state) {
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
   if (TMC_SW_SPI == nullptr) {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
   }

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -16,9 +16,10 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link_index) :
   _pinMOSI(0),
   _pinSCK(0),
   _has_pins(false),
+  TMC_SW_SPI(nullptr),
+  _spiMan(nullptr),
   link_index(link_index)
   {
-    TMC_SW_SPI = nullptr;
     defaults();
 
     if (link_index > chain_length)
@@ -32,6 +33,7 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMIS
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   link_index(link)
   {
     if (softSPI)
@@ -56,6 +58,7 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   link_index(link)
   {
     if (softSPI)
@@ -67,6 +70,23 @@ TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
     {
       TMC_SW_SPI = nullptr;
     }
+    defaults();
+
+    if (link > chain_length)
+      chain_length = link;
+  }
+
+TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link) :
+  TMCStepper(RS),
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  TMC_SW_SPI(nullptr),
+  _spiMan(spiMan),
+  link_index(link)
+  {
     defaults();
 
     if (link > chain_length)
@@ -105,7 +125,10 @@ void TMC2130Stepper::switchCSpin(bool state) {
 
 __attribute__((weak))
 void TMC2130Stepper::beginTransaction() {
-  if (TMC_SW_SPI == nullptr) {
+  if (_spiMan) {
+    _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
+  }
+  else if (TMC_SW_SPI == nullptr) {
     if (_has_pins)
     {
       SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
@@ -117,7 +140,10 @@ void TMC2130Stepper::beginTransaction() {
 }
 __attribute__((weak))
 void TMC2130Stepper::endTransaction() {
-  if (TMC_SW_SPI == nullptr) {
+  if (_spiMan) {
+    _spiMan->end();
+  }
+  else if (TMC_SW_SPI == nullptr) {
     SPI.endTransaction();
     SPI.end();
   }
@@ -126,7 +152,10 @@ void TMC2130Stepper::endTransaction() {
 __attribute__((weak))
 uint8_t TMC2130Stepper::transfer(const uint8_t data) {
   uint8_t out = 0;
-  if (TMC_SW_SPI != nullptr) {
+  if (_spiMan) {
+    out = _spiMan->transfer(data);
+  }
+  else if (TMC_SW_SPI != nullptr) {
     out = TMC_SW_SPI->transfer(data);
   }
   else {
@@ -136,8 +165,13 @@ uint8_t TMC2130Stepper::transfer(const uint8_t data) {
 }
 
 void TMC2130Stepper::transferEmptyBytes(const uint8_t n) {
-  for (uint8_t i = 0; i < n; i++) {
-    transfer(0x00);
+  if (_spiMan) {
+    _spiMan->sendRepeat(0, n);
+  }
+  else {
+    for (uint8_t i = 0; i < n; i++) {
+      transfer(0x00);
+    }
   }
 }
 

--- a/src/source/TMC2130Stepper.h
+++ b/src/source/TMC2130Stepper.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include "TMCStepper_SPI.h"
+
 #define INIT2130_REGISTER(REG) TMC2130_n::REG##_t REG##_register{}
 
 class TMC2130Stepper : public TMCStepper {
@@ -13,6 +15,7 @@ class TMC2130Stepper : public TMCStepper {
 		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link_index = -1);
 		void begin();
 		void defaults();
 		void setSPISpeed(uint32_t speed);
@@ -231,6 +234,7 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const TMCSPIInterface *_spiMan;
 		const bool _has_pins;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;

--- a/src/source/TMC2130Stepper.h
+++ b/src/source/TMC2130Stepper.h
@@ -13,8 +13,8 @@
 class TMC2130Stepper : public TMCStepper {
 	public:
 		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 		TMC2130Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link_index = -1);
 		void begin();
 		void defaults();

--- a/src/source/TMC2130Stepper.h
+++ b/src/source/TMC2130Stepper.h
@@ -10,9 +10,9 @@
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
 		void defaults();
 		void setSPISpeed(uint32_t speed);
@@ -228,6 +228,9 @@ class TMC2130Stepper : public TMCStepper {
 
 		static uint32_t spi_speed; // Default 2MHz
 		const uint16_t _pinCS;
+		const uint16_t _pinMISO;
+		const uint16_t _pinMOSI;
+		const uint16_t _pinSCK;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;
 

--- a/src/source/TMC2130Stepper.h
+++ b/src/source/TMC2130Stepper.h
@@ -10,7 +10,7 @@
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
@@ -231,6 +231,7 @@ class TMC2130Stepper : public TMCStepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const bool _has_pins;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;
 

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -6,6 +6,9 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC2130Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -6,13 +6,11 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC2160Stepper::begin() {

--- a/src/source/TMC2160Stepper.h
+++ b/src/source/TMC2160Stepper.h
@@ -10,7 +10,7 @@
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();

--- a/src/source/TMC2160Stepper.h
+++ b/src/source/TMC2160Stepper.h
@@ -11,8 +11,8 @@
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
 		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 		void begin();
 		void defaults();
 		void push();

--- a/src/source/TMC2160Stepper.h
+++ b/src/source/TMC2160Stepper.h
@@ -10,9 +10,9 @@
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		void begin();
 		void defaults();
 		void push();

--- a/src/source/TMC2240Stepper.cpp
+++ b/src/source/TMC2240Stepper.cpp
@@ -10,6 +10,10 @@ uint32_t TMC2240Stepper::spi_speed = 16000000/8;
 
 TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, int8_t link) :
 	_pinCS(pinCS),
+	_pinMISO(0),
+	_pinMOSI(0),
+	_pinSCK(0),
+	_has_pins(false),
 	link_index(link)
 	{
 		defaults();
@@ -20,6 +24,10 @@ TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, int8_t link) :
 
 TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
 	_pinCS(pinCS),
+	_pinMISO(pinMISO),
+	_pinMOSI(pinMOSI),
+	_pinSCK(pinSCK),
+	_has_pins(true),
 	link_index(link)
 	{
 		SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
@@ -29,6 +37,48 @@ TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMIS
 		if (link > chain_length)
 			chain_length = link;
 	}
+
+TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMCStepper(default_RS),
+  _pinCS(pinCS),
+  _pinMISO(pinMISO),
+  _pinMOSI(pinMOSI),
+  _pinSCK(pinSCK),
+  _has_pins(true),
+  _spiMan(nullptr),
+  link_index(link)
+  {
+    if (softSPI)
+    {
+      SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
+      TMC_SW_SPI = SW_SPI_Obj;
+    }
+    else
+    {
+      TMC_SW_SPI = nullptr;
+    }
+    defaults();
+
+    if (link > chain_length)
+      chain_length = link;
+  }
+
+TMC2240Stepper::TMC2240Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan, int8_t link) :
+  TMCStepper(RS),
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  TMC_SW_SPI(nullptr),
+  _spiMan(spiMan),
+  link_index(link)
+  {
+    defaults();
+
+    if (link > chain_length)
+      chain_length = link;
+  }
 
 void TMC2240Stepper::defaults() {
 	GCONF_register.multistep_filt = 1;

--- a/src/source/TMC2240Stepper.h
+++ b/src/source/TMC2240Stepper.h
@@ -11,7 +11,8 @@
 class TMC2240Stepper {
 	public:
 		TMC2240Stepper(uint16_t pinCS, int8_t link_index = -1);
-		TMC2240Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC2240Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC2240Stepper(uint16_t pinCS, TMCSPIInterface *spiMan, int8_t link_index = -1);
 
 		/**
 		 * ('rref', 12000, minval=12000, maxval=60000)
@@ -362,6 +363,11 @@ class TMC2240Stepper {
 
 		static uint32_t spi_speed; // Default 2MHz
 		const uint16_t _pinCS;
+		const uint16_t _pinMISO;
+		const uint16_t _pinMOSI;
+		const uint16_t _pinSCK;
+		const TMCSPIInterface *_spiMan;
+		const bool _has_pins;
 		SW_SPIClass * TMC_SW_SPI = nullptr;
 		static constexpr float default_RS = 0.11;
 

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -57,9 +57,9 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
   } else {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
@@ -83,9 +83,9 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
   } else {
-    SPI.setMISO(_pinMISO);
-    SPI.setMOSI(_pinMOSI);
-    SPI.setSCLK(_pinSCK);
+    SPI_INIT_PIN( SPI, MISO, _pinMISO );
+    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -11,9 +11,11 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS) :
   _pinMOSI(0),
   _pinSCK(0),
   _has_pins(false),
-  Rsense(RS)
+  _spiMan(nullptr),
+  Rsense(RS),
+  TMC_SW_SPI(nullptr)
   {
-    TMC_SW_SPI = nullptr;
+    return;
   }
 
 TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
@@ -22,6 +24,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMIS
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   Rsense(default_RS)
   {
     if (softSPI)
@@ -41,6 +44,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
   _has_pins(true),
+  _spiMan(nullptr),
   Rsense(RS)
   {
     if (softSPI)
@@ -54,6 +58,19 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
     }
   }
 
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan) :
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  _spiMan(spiMan),
+  Rsense(RS),
+  TMC_SW_SPI(nullptr)
+  {
+    return;
+  }
+
 void TMC2660Stepper::switchCSpin(bool state) {
   // Allows for overriding in child class to make use of fast io
   digitalWrite(_pinCS, state);
@@ -62,7 +79,17 @@ void TMC2660Stepper::switchCSpin(bool state) {
 uint32_t TMC2660Stepper::read() {
   uint32_t response = 0UL;
   uint32_t dummy = ((uint32_t)DRVCONF_register.address<<17) | DRVCONF_register.sr;
-  if (TMC_SW_SPI != nullptr) {
+  if (_spiMan) {
+    _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
+    switchCSpin(LOW);
+    response |= _spiMan->transfer((dummy >> 16) & 0xFF);
+    response <<= 8;
+    response |= _spiMan->transfer((dummy >>  8) & 0xFF);
+    response <<= 8;
+    response |= _spiMan->transfer(dummy & 0xFF);
+    _spiMan->end();
+  }
+  else if (TMC_SW_SPI != nullptr) {
     switchCSpin(LOW);
     response |= TMC_SW_SPI->transfer((dummy >> 16) & 0xFF);
     response <<= 8;
@@ -92,7 +119,15 @@ uint32_t TMC2660Stepper::read() {
 
 void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
   uint32_t data = (uint32_t)addressByte<<17 | config;
-  if (TMC_SW_SPI != nullptr) {
+  if (_spiMan) {
+    _spiMan->begin(spi_speed, TMCSPI_BITORDER_MSB, TMCSPI_CLKMODE_3);
+    switchCSpin(LOW);
+    _spiMan->transfer((data >> 16) & 0xFF);
+    _spiMan->transfer((data >>  8) & 0xFF);
+    _spiMan->transfer(data & 0xFF);
+    _spiMan->end();
+  }
+  else if (TMC_SW_SPI != nullptr) {
     switchCSpin(LOW);
     TMC_SW_SPI->transfer((data >> 16) & 0xFF);
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -72,11 +72,10 @@ uint32_t TMC2660Stepper::read() {
   } else {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     response |= SPI.transfer((dummy >> 16) & 0xFF);
@@ -101,11 +100,10 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
   } else {
     if (_has_pins)
     {
-      SPI_INIT_PIN( SPI, MISO, _pinMISO );
-      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+      SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
     }
-    SPI.begin();
+    else
+      SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     SPI.transfer((data >> 16) & 0xFF);

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -5,25 +5,40 @@
 #include "../TMCStepper.h"
 #include "SW_SPI.h"
 
-TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS) :
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
   _pinCS(pinCS),
-  Rsense(RS)
-  {}
-
-TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
-  _pinCS(pinCS),
+  _pinMISO(pinMISO),
+  _pinMOSI(pinMOSI),
+  _pinSCK(pinSCK),
   Rsense(default_RS)
   {
-    SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
-    TMC_SW_SPI = SW_SPI_Obj;
+    if (softSPI)
+    {
+      SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
+      TMC_SW_SPI = SW_SPI_Obj;
+    }
+    else
+    {
+      TMC_SW_SPI = nullptr;
+    }
   }
 
-TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK) :
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
   _pinCS(pinCS),
+  _pinMISO(pinMISO),
+  _pinMOSI(pinMOSI),
+  _pinSCK(pinSCK),
   Rsense(RS)
   {
-    SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
-    TMC_SW_SPI = SW_SPI_Obj;
+    if (softSPI)
+    {
+      SW_SPIClass *SW_SPI_Obj = new SW_SPIClass(pinMOSI, pinMISO, pinSCK);
+      TMC_SW_SPI = SW_SPI_Obj;
+    }
+    else
+    {
+      TMC_SW_SPI = nullptr;
+    }
   }
 
 void TMC2660Stepper::switchCSpin(bool state) {
@@ -42,6 +57,10 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
   } else {
+    SPI.setMISO(_pinMISO);
+    SPI.setMOSI(_pinMOSI);
+    SPI.setSCLK(_pinSCK);
+    SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     response |= SPI.transfer((dummy >> 16) & 0xFF);
@@ -50,6 +69,7 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= SPI.transfer(dummy & 0xFF);
     SPI.endTransaction();
+    SPI.end();
   }
   switchCSpin(HIGH);
   return response >> 4;
@@ -63,12 +83,17 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
   } else {
+    SPI.setMISO(_pinMISO);
+    SPI.setMOSI(_pinMOSI);
+    SPI.setSCLK(_pinSCK);
+    SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
     SPI.transfer((data >> 16) & 0xFF);
     SPI.transfer((data >>  8) & 0xFF);
     SPI.transfer(data & 0xFF);
     SPI.endTransaction();
+    SPI.end();
   }
   switchCSpin(HIGH);
 }

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -96,7 +96,9 @@ uint32_t TMC2660Stepper::read() {
     response |= TMC_SW_SPI->transfer((dummy >>  8) & 0xFF);
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
-  } else {
+  }
+#ifndef TMC_NO_GENERIC_SPI
+  else {
     if (_has_pins)
     {
       SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
@@ -113,6 +115,7 @@ uint32_t TMC2660Stepper::read() {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
   switchCSpin(HIGH);
   return response >> 4;
 }
@@ -132,7 +135,9 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >> 16) & 0xFF);
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
-  } else {
+  }
+#ifndef TMC_NO_GENERIC_SPI
+  else {
     if (_has_pins)
     {
       SPI_BEGIN( SPI, _pinSCK, _pinMISO, _pinMOSI );
@@ -147,6 +152,7 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     SPI.endTransaction();
     SPI.end();
   }
+#endif
   switchCSpin(HIGH);
 }
 

--- a/src/source/TMC2660Stepper.cpp
+++ b/src/source/TMC2660Stepper.cpp
@@ -5,11 +5,23 @@
 #include "../TMCStepper.h"
 #include "SW_SPI.h"
 
+TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS) :
+  _pinCS(pinCS),
+  _pinMISO(0),
+  _pinMOSI(0),
+  _pinSCK(0),
+  _has_pins(false),
+  Rsense(RS)
+  {
+    TMC_SW_SPI = nullptr;
+  }
+
 TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, bool softSPI) :
   _pinCS(pinCS),
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   Rsense(default_RS)
   {
     if (softSPI)
@@ -28,6 +40,7 @@ TMC2660Stepper::TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint1
   _pinMISO(pinMISO),
   _pinMOSI(pinMOSI),
   _pinSCK(pinSCK),
+  _has_pins(true),
   Rsense(RS)
   {
     if (softSPI)
@@ -57,9 +70,12 @@ uint32_t TMC2660Stepper::read() {
     response <<= 8;
     response |= TMC_SW_SPI->transfer(dummy & 0xFF);
   } else {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);
@@ -83,9 +99,12 @@ void TMC2660Stepper::write(uint8_t addressByte, uint32_t config) {
     TMC_SW_SPI->transfer((data >>  8) & 0xFF);
     TMC_SW_SPI->transfer(data & 0xFF);
   } else {
-    SPI_INIT_PIN( SPI, MISO, _pinMISO );
-    SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
-    SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    if (_has_pins)
+    {
+      SPI_INIT_PIN( SPI, MISO, _pinMISO );
+      SPI_INIT_PIN( SPI, MOSI, _pinMOSI );
+      SPI_INIT_PIN( SPI, SCLK, _pinSCK );
+    }
     SPI.begin();
     SPI.beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
     switchCSpin(LOW);

--- a/src/source/TMC2660Stepper.h
+++ b/src/source/TMC2660Stepper.h
@@ -165,6 +165,7 @@ class TMC2660Stepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const bool _has_pins;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;
 		float holdMultiplier = 0.5;

--- a/src/source/TMC2660Stepper.h
+++ b/src/source/TMC2660Stepper.h
@@ -162,6 +162,9 @@ class TMC2660Stepper {
 		INIT_REGISTER(READ_RDSEL10);
 
 		const uint16_t _pinCS;
+		const uint16_t _pinMISO;
+		const uint16_t _pinMOSI;
+		const uint16_t _pinSCK;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;
 		float holdMultiplier = 0.5;

--- a/src/source/TMC2660Stepper.h
+++ b/src/source/TMC2660Stepper.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include "TMCStepper_SPI.h"
+
 #define INIT2660_REGISTER(REG) TMC2660_n::REG##_t REG##_register{}
 
 class TMC2660Stepper {
@@ -13,6 +15,7 @@ class TMC2660Stepper {
 		TMC2660Stepper(uint16_t pinCS, float RS = default_RS);
 		TMC2660Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
 		TMC2660Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK);
+		TMC2660Stepper(uint16_t pinCS, float RS, TMCSPIInterface *spiMan);
 		void write(uint8_t addressByte, uint32_t config);
 		uint32_t read();
 		void switchCSpin(bool state);
@@ -165,6 +168,7 @@ class TMC2660Stepper {
 		const uint16_t _pinMISO;
 		const uint16_t _pinMOSI;
 		const uint16_t _pinSCK;
+		const TMCSPIInterface *_spiMan;
 		const bool _has_pins;
 		const float Rsense;
 		static constexpr float default_RS = 0.1;

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -6,13 +6,11 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI):
+  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link):
-  TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC2160Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC5130Stepper::begin() {

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -6,6 +6,9 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC2160Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI):
   TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }

--- a/src/source/TMC5130Stepper.h
+++ b/src/source/TMC5130Stepper.h
@@ -11,8 +11,8 @@
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
 		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 
 		void begin();
 		void defaults();

--- a/src/source/TMC5130Stepper.h
+++ b/src/source/TMC5130Stepper.h
@@ -10,9 +10,9 @@
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
 		void begin();
 		void defaults();

--- a/src/source/TMC5130Stepper.h
+++ b/src/source/TMC5130Stepper.h
@@ -10,7 +10,7 @@
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -6,6 +6,9 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link_index) :
+  TMC5130Stepper(pinCS, RS, link_index)
+  { defaults(); }
 TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
   TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -6,13 +6,11 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
-  { defaults(); }
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
-  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link)
+TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link, bool softSPI) :
+  TMC5130Stepper(pinCS, default_RS, pinMOSI, pinMISO, pinSCK, link, softSPI)
   { defaults(); }
 
 void TMC5160Stepper::defaults() {

--- a/src/source/TMC5160Stepper.h
+++ b/src/source/TMC5160Stepper.h
@@ -11,8 +11,8 @@
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
 		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
-		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
+		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = _TMC_SOFTSPI_DEFAULT);
 
 		void rms_current(uint16_t mA) { TMC2160Stepper::rms_current(mA); }
 		void rms_current(uint16_t mA, float mult) { TMC2160Stepper::rms_current(mA, mult); }

--- a/src/source/TMC5160Stepper.h
+++ b/src/source/TMC5160Stepper.h
@@ -10,9 +10,9 @@
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
-		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
+		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 
 		void rms_current(uint16_t mA) { TMC2160Stepper::rms_current(mA); }
 		void rms_current(uint16_t mA, float mult) { TMC2160Stepper::rms_current(mA, mult); }

--- a/src/source/TMC5160Stepper.h
+++ b/src/source/TMC5160Stepper.h
@@ -10,7 +10,7 @@
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1, bool softSPI = false);
+		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
 		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1, bool softSPI = false);
 

--- a/src/source/TMC5161Stepper.h
+++ b/src/source/TMC5161Stepper.h
@@ -8,7 +8,8 @@
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
-		TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
+		TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) :
+			TMC5160Stepper(pinCS, RS, link_index) {}
 		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
 			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
 		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :


### PR DESCRIPTION
In case this is still valuable, it is rebased on the fork we are maintaining for quicker turnaround. I've ported the additions for 2130 / 2260 for the new TMC2240. Evaluate and have fun bus sharing!

Based on PR teemuatlut/TMCStepper#255 by @quiret.

---

> * fixed SPI bus sharing between TFT, SD, Touch, etc in combination with TMC by properly initializing and then terminating the SPI usage
> 
> in the way that this library was previously written it was not easy to share the SPI bus between components because the SPI protocol was not properly terminated/cleaned-up across SPI sessions, causing conflicts for different SPI bus components. This library has been tested with Marlin 2.1.x bugfix on this repo: github.com/quiret/Marlin/
> 
> There is a Marlin pull request that would really appreciate this improvement: MarlinFirmware/Marlin#24911
> 
> Please consider releasing another version of this library with the included fix onto platformio so that the Marlin FW can be really improved! clobbering the global SPI object is not a good idea, especially on single-SPI boards...
> 
> Martin Turski, company owner of EirDev
