### PR TITLE
✨ ESP-IDF Compatibility - Redo PR 194

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRC_DIRS src/source
+                       INCLUDE_DIRS "src"
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wfatal-errors)

--- a/src/TMCStepper.h
+++ b/src/TMCStepper.h
@@ -32,6 +32,9 @@
 	#include <bcm2835.h>
 	#include "source/bcm2835_spi.h"
 	#include "source/bcm2835_stream.h"
+#elif defined(ESP_PLATFORM)
+	#include "source/ESP32_Serial.h"
+	#include "source/ESP32_SPI.h"
 #elif defined(__has_include)
 	#if __has_include(<Arduino.h>)
 		#include <Arduino.h>

--- a/src/source/ESP32_Adapter.cpp
+++ b/src/source/ESP32_Adapter.cpp
@@ -1,0 +1,25 @@
+#include "ESP32_Adapter.h"
+
+#ifdef ESP_PLATFORM
+    void pinMode( uint16_t num, gpio_dir_t mode ) {
+        switch( mode ) {
+            case OUTPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_OUTPUT );
+                break;
+            case INPUT:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_FLOATING );
+                break;
+            case INPUT_PULLUP:
+                gpio_set_direction( (gpio_num_t)num, GPIO_MODE_INPUT );
+                gpio_set_pull_mode( (gpio_num_t)num, GPIO_PULLUP_ONLY );
+                break;
+        }
+    }
+    void digitalWrite( uint16_t num, uint32_t level ) {
+        gpio_set_level( (gpio_num_t)num, level );
+    }
+    int digitalRead( uint16_t num ) {
+        return gpio_get_level( (gpio_num_t)num );
+    }
+#endif

--- a/src/source/ESP32_Adapter.h
+++ b/src/source/ESP32_Adapter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+	#include <cstdint>
+	#include <driver/gpio.h>
+	#define LOW  0
+	#define HIGH 1
+	typedef enum {
+		OUTPUT,
+		INPUT,
+		INPUT_PULLUP
+	} gpio_dir_t;
+	void pinMode( uint16_t num, gpio_dir_t mode );
+	void digitalWrite( uint16_t num, uint32_t level );
+	int digitalRead( uint16_t num );
+#endif

--- a/src/source/ESP32_SPI.cpp
+++ b/src/source/ESP32_SPI.cpp
@@ -1,0 +1,7 @@
+#ifdef ESP_PLATFORM
+
+#include "ESP32_SPI.h"
+
+SPIClass SPI;
+
+#endif

--- a/src/source/ESP32_SPI.h
+++ b/src/source/ESP32_SPI.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/*
+****************************************************
+DUMMY IMPLEMENTATION
+****************************************************
+DOES NOT ACTUALLY DO ANYTHING
+****************************************************
+*/
+
+#ifdef ESP_PLATFORM
+
+#include <cstdint>
+
+#define MSBFIRST 0
+#define SPI_MODE0 0
+#define SPI_MODE1 1
+#define SPI_MODE2 2
+#define SPI_MODE3 3
+
+class SPIClass;
+
+struct SPISettings
+{
+	friend class SPIClass;
+	SPISettings(uint32_t s, uint32_t o, uint32_t m) {
+		speed = s;
+		order = o;
+		mode = m;
+	}
+
+	uint32_t speed;
+	uint32_t order;
+	uint32_t mode;
+};
+
+class SPIClass
+{
+public:
+	void beginTransaction(SPISettings settings) {}
+	void endTransaction() {}
+	uint8_t transfer(uint8_t) {
+		return 0;
+	}
+};
+
+extern SPIClass SPI;
+#endif

--- a/src/source/ESP32_Serial.cpp
+++ b/src/source/ESP32_Serial.cpp
@@ -1,0 +1,80 @@
+#include "ESP32_Serial.h"
+
+#ifdef ESP_PLATFORM
+
+	#define LOG_LOCAL_LEVEL ESP_LOG_INFO
+	#define TAG_EPS32_SERIAL "ESP32_UART"
+	#include <esp_log.h>
+	#include <hal/gpio_types.h>
+
+	ESP32_Serial::ESP32_Serial( int baud_rate, int rx_pin, int tx_pin, uart_port_t uart_num_new ) {
+		uart_num = uart_num_new;
+		ready = false;
+		uart_config_t uart_config = {
+			.baud_rate = baud_rate,
+			.data_bits = UART_DATA_8_BITS,
+			.parity    = UART_PARITY_DISABLE,
+			.stop_bits = UART_STOP_BITS_1,
+			.flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+			.rx_flow_ctrl_thresh = 0,
+			.source_clk = UART_SCLK_APB,
+		};
+		if( ESP_OK == uart_driver_install( uart_num, 2048, 0, 0, NULL, 0 ) ) {
+			if( ESP_OK == uart_param_config( uart_num, &uart_config ) ) {
+				if( ESP_OK == uart_set_pin( uart_num, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE ) ) {
+					ready = true;
+				}
+				else {
+					ESP_LOGE( TAG_EPS32_SERIAL, "Unable to set UART pins." );
+				}
+			}
+			else {
+				ESP_LOGE( TAG_EPS32_SERIAL, "Unable to configure UART." );
+			}
+		}
+		else {
+			ESP_LOGE( TAG_EPS32_SERIAL, "Unable to install UART driver." );
+		}
+	}
+
+	int16_t ESP32_Serial::read() {
+		if( !ready ) {
+			ESP_LOGE( TAG_EPS32_SERIAL, "Trying to read from not ready UART." );
+			return -1;
+		}
+		uint8_t data = 0;
+		int len = uart_read_bytes( uart_num, &data, 1, 0 );
+		ESP_LOGD( TAG_EPS32_SERIAL, "Read data: %X (length %d)", data, len );
+		if( len < 1 ) return -1;
+		else return data;
+	}
+
+	uint8_t ESP32_Serial::write( const uint8_t data ) {
+		if( !ready ) {
+			ESP_LOGE( TAG_EPS32_SERIAL, "Trying to write to not ready UART." );
+			return 0;
+		}
+		ESP_LOGD( TAG_EPS32_SERIAL, "Write data: %X", data );
+		int len = uart_write_bytes( uart_num, (const char*)&data, 1);
+		ESP_LOGD( TAG_EPS32_SERIAL, "Number of bytes written: %d", len );
+		if( len < 1 ) return 0;
+		else return len;
+	}
+
+	size_t ESP32_Serial::available() {
+		if( !ready ) {
+			ESP_LOGE( TAG_EPS32_SERIAL, "Trying to get available bytes from not ready UART." );
+			return 0;
+		}
+		size_t len = 0;
+		if( ESP_OK == uart_get_buffered_data_len( uart_num, &len ) ) {
+			ESP_LOGD( TAG_EPS32_SERIAL, "Number of bytes available: %d", len );
+			return len;
+		}
+		else {
+			ESP_LOGE( TAG_EPS32_SERIAL, "Error getting available bytes." );
+			return 0;
+		}
+	}
+
+#endif // ESP_PLATFORM

--- a/src/source/ESP32_Serial.h
+++ b/src/source/ESP32_Serial.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+	#include <cstdint>
+
+	#include <driver/uart.h>
+
+	class ESP32_Serial {
+		public:
+			ESP32_Serial( int baud_rate, int rx_pin = 16, int tx_pin = 17, uart_port_t uart_num_new = UART_NUM_2 );
+
+			int16_t read();
+			uint8_t write( const uint8_t data );
+			size_t available();
+
+		private:
+			bool ready;
+			uart_port_t uart_num;
+	};
+#endif

--- a/src/source/SERIAL_SWITCH.cpp
+++ b/src/source/SERIAL_SWITCH.cpp
@@ -3,6 +3,7 @@
  * SERIAL_SWITCH.cpp - Serial Switch for Arduino / Raspberry Pi
  */
 #include "SERIAL_SWITCH.h"
+#include "ESP32_Adapter.h"
 
 SSwitch::SSwitch( const uint16_t pin1, const uint16_t pin2, const uint8_t address) :
   p1(pin1),

--- a/src/source/SERIAL_SWITCH.h
+++ b/src/source/SERIAL_SWITCH.h
@@ -14,6 +14,7 @@
 		#include <Arduino.h>
 	#endif
 #endif
+#include <cstdint>
 
 #include "TMC_platforms.h"
 

--- a/src/source/SW_SPI.cpp
+++ b/src/source/SW_SPI.cpp
@@ -3,6 +3,7 @@
  * SW_SPI.cpp - Software SPI for Arduino or Raspberry Pi
  */
 #include "SW_SPI.h"
+#include "ESP32_Adapter.h"
 
 SW_SPIClass::SW_SPIClass(uint16_t mosi, uint16_t miso, uint16_t sck) :
   mosi_pin(mosi),

--- a/src/source/SW_SPI.h
+++ b/src/source/SW_SPI.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 #if defined(ARDUINO) && ARDUINO >= 100
 	#include <Arduino.h>
 #elif defined(bcm2835)
@@ -22,16 +24,16 @@ class SW_SPIClass {
 	public:
 		SW_SPIClass(uint16_t sw_mosi_pin, uint16_t sw_miso_pin, uint16_t sw_sck_pin);
 		void init();
-		void begin() {};
+		void begin() {}
 		uint8_t transfer(uint8_t ulVal);
 		uint16_t transfer16(uint16_t data);
-		void endTransaction() {};
+		void endTransaction() {}
 	private:
 		const uint16_t	mosi_pin,
 						miso_pin,
 						sck_pin;
 
-		#if defined(ARDUINO_ARCH_AVR)
+		#ifdef ARDUINO_ARCH_AVR
 			fastio_bm mosi_bm,
 					miso_bm,
 					sck_bm;

--- a/src/source/TMC2130Stepper.cpp
+++ b/src/source/TMC2130Stepper.cpp
@@ -9,16 +9,18 @@
 int8_t TMC2130Stepper::chain_length = 0;
 uint32_t TMC2130Stepper::spi_speed = 16000000/8;
 
-TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
-  TMCStepper(RS),
-  _pinCS(pinCS),
-  link_index(link)
+#ifndef ESP_PLATFORM
+  TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, float RS, int8_t link) :
+    TMCStepper(RS),
+    _pinCS(pinCS),
+    link_index(link)
   {
     defaults();
 
     if (link > chain_length)
       chain_length = link;
   }
+#endif
 
 TMC2130Stepper::TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMCStepper(default_RS),

--- a/src/source/TMC2130Stepper.h
+++ b/src/source/TMC2130Stepper.h
@@ -10,7 +10,9 @@
 
 class TMC2130Stepper : public TMCStepper {
 	public:
-		TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#ifndef ESP_PLATFORM
+			TMC2130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC2130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC2130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();

--- a/src/source/TMC2160Stepper.cpp
+++ b/src/source/TMC2160Stepper.cpp
@@ -6,8 +6,10 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
-  { defaults(); }
+#ifndef ESP_PLATFORM
+  TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2130Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC2160Stepper::TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMC2130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC2160Stepper.h
+++ b/src/source/TMC2160Stepper.h
@@ -10,7 +10,9 @@
 
 class TMC2160Stepper : public TMC2130Stepper {
 	public:
-		TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#ifndef ESP_PLATFORM
+			TMC2160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC2160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC2160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		void begin();

--- a/src/source/TMC2208Stepper.cpp
+++ b/src/source/TMC2208Stepper.cpp
@@ -7,9 +7,21 @@
 #include "TMC_MACROS.h"
 #include "SERIAL_SWITCH.h"
 
+#ifdef ESP_PLATFORM
+	#include <esp32/rom/ets_sys.h>
+	#include <esp_timer.h>
+	uint32_t millis() {
+		return esp_timer_get_time() / 1000;
+	}
+#endif
+
 // Protected
 // addr needed for TMC2209
+#ifdef ESP_PLATFORM
+TMC2208Stepper::TMC2208Stepper(ESP32_Serial * SerialPort, float RS, uint8_t addr) :
+#else
 TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr) :
+#endif
 	TMCStepper(RS),
 	slave_address(addr)
 	{
@@ -17,7 +29,11 @@ TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr) :
 		defaults();
 	}
 
+#ifdef ESP_PLATFORM
+TMC2208Stepper::TMC2208Stepper( ESP32_Serial * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2) :
+#else
 TMC2208Stepper::TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2) :
+#endif
 	TMC2208Stepper(SerialPort, RS)
 	{
 		SSwitch *SMulObj = new SSwitch(mul_pin1, mul_pin2, addr);
@@ -230,7 +246,11 @@ void TMC2208Stepper::write(uint8_t addr, uint32_t regVal) {
 	}
 	postWriteCommunication();
 
-	delay(replyDelay);
+	#ifdef ESP_PLATFORM
+		ets_delay_us( replyDelay * 1000 );
+	#else
+		delay(replyDelay);
+	#endif
 }
 
 uint64_t TMC2208Stepper::_sendDatagram(uint8_t datagram[], const uint8_t len, uint16_t timeout) {
@@ -251,7 +271,11 @@ uint64_t TMC2208Stepper::_sendDatagram(uint8_t datagram[], const uint8_t len, ui
 		}
 	#endif
 
-	delay(this->replyDelay);
+	#ifdef ESP_PLATFORM
+		ets_delay_us( replyDelay * 1000 );
+	#else
+		delay(this->replyDelay);
+	#endif
 
 	// scan for the rx frame and read it
 	uint32_t ms = millis();
@@ -323,7 +347,11 @@ uint32_t TMC2208Stepper::read(uint8_t addr) {
 		out = _sendDatagram(datagram, len, abort_window);
 		postReadCommunication();
 
-		delay(replyDelay);
+		#ifdef ESP_PLATFORM
+			ets_delay_us( replyDelay * 1000 );
+		#else
+			delay(replyDelay);
+		#endif
 
 		CRCerror = false;
 		uint8_t out_datagram[] = {

--- a/src/source/TMC2208Stepper.h
+++ b/src/source/TMC2208Stepper.h
@@ -10,10 +10,17 @@
 
 class TMC2208Stepper : public TMCStepper {
 	public:
-		TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
-		TMC2208Stepper(Stream * SerialPort, float RS) :
-			TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
-			{}
+		#ifdef ESP_PLATFORM
+			TMC2208Stepper( ESP32_Serial * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
+			TMC2208Stepper( ESP32_Serial * SerialPort, float RS) :
+				TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
+				{}
+		#else
+			TMC2208Stepper(Stream * SerialPort, float RS, uint8_t addr, uint16_t mul_pin1, uint16_t mul_pin2);
+			TMC2208Stepper(Stream * SerialPort, float RS) :
+				TMC2208Stepper(SerialPort, RS, TMC2208_SLAVE_ADDR)
+				{}
+		#endif
 		#if TMCSTEPPER_SW_SERIAL
 			TMC2208Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS) :
 				TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, TMC2208_SLAVE_ADDR)
@@ -22,7 +29,7 @@ class TMC2208Stepper : public TMCStepper {
 			__attribute__((deprecated("Boolean argument has been deprecated and does nothing")))
 			TMC2208Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, bool) :
 				TMC2208Stepper(SW_RX_pin, SW_TX_pin, RS, TMC2208_SLAVE_ADDR)
-				{};
+				{}
 		#else
 			TMC2208Stepper(uint16_t, uint16_t, float) = delete; // Your platform does not currently support Software Serial
 		#endif

--- a/src/source/TMC2209Stepper.h
+++ b/src/source/TMC2209Stepper.h
@@ -10,8 +10,13 @@
 
 class TMC2209Stepper : public TMC2208Stepper {
 	public:
-		TMC2209Stepper(Stream * SerialPort, float RS, uint8_t addr) :
-			TMC2208Stepper(SerialPort, RS, addr) {}
+		#ifdef ESP_PLATFORM
+			TMC2209Stepper(ESP32_Serial * SerialPort, float RS, uint8_t addr);
+			ESP32_Serial * HWSerial = nullptr;
+		#else
+			TMC2209Stepper(Stream * SerialPort, float RS, uint8_t addr) :
+				TMC2208Stepper(SerialPort, RS, addr) {}
+		#endif
 
 		#if TMCSTEPPER_SW_SERIAL
 			TMC2209Stepper(uint16_t SW_RX_pin, uint16_t SW_TX_pin, float RS, uint8_t addr) :

--- a/src/source/TMC5130Stepper.cpp
+++ b/src/source/TMC5130Stepper.cpp
@@ -6,8 +6,10 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
-  { defaults(); }
+#ifndef ESP_PLATFORM
+  TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, int8_t link) : TMC2160Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC5130Stepper::TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link):
   TMC2160Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC5130Stepper.h
+++ b/src/source/TMC5130Stepper.h
@@ -10,7 +10,9 @@
 
 class TMC5130Stepper : public TMC2160Stepper {
 	public:
-		TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#ifndef ESP_PLATFORM
+			TMC5130Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC5130Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC5130Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 

--- a/src/source/TMC5160Stepper.cpp
+++ b/src/source/TMC5160Stepper.cpp
@@ -6,8 +6,10 @@
 #include "../TMCStepper.h"
 #include "TMC_MACROS.h"
 
-TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
-  { defaults(); }
+#ifndef ESP_PLATFORM
+  TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, int8_t link) : TMC5130Stepper(pinCS, RS, link)
+    { defaults(); }
+#endif
 TMC5160Stepper::TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link) :
   TMC5130Stepper(pinCS, RS, pinMOSI, pinMISO, pinSCK, link)
   { defaults(); }

--- a/src/source/TMC5160Stepper.h
+++ b/src/source/TMC5160Stepper.h
@@ -10,7 +10,9 @@
 
 class TMC5160Stepper : public TMC5130Stepper {
 	public:
-		TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#ifndef ESP_PLATFORM
+			TMC5160Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1);
+		#endif
 		TMC5160Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 		TMC5160Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1);
 

--- a/src/source/TMC5161Stepper.h
+++ b/src/source/TMC5161Stepper.h
@@ -8,7 +8,10 @@
 
 class TMC5161Stepper : public TMC5160Stepper {
 	public:
-		TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) : TMC5160Stepper(pinCS, RS, link_index) {}
+		#ifndef ESP_PLATFORM
+			TMC5161Stepper(uint16_t pinCS, float RS = default_RS, int8_t link_index = -1) :
+				TMC5160Stepper(pinCS, RS, link_index) {}
+		#endif
 		TMC5161Stepper(uint16_t pinCS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :
 			TMC5160Stepper(pinCS, pinMOSI, pinMISO, pinSCK, link_index) {}
 		TMC5161Stepper(uint16_t pinCS, float RS, uint16_t pinMOSI, uint16_t pinMISO, uint16_t pinSCK, int8_t link_index = -1) :

--- a/src/source/TMC_platforms.h
+++ b/src/source/TMC_platforms.h
@@ -4,6 +4,8 @@
  *
  * Define SPI accessors for AVR, DUE (700kHz), LPC1768, STM32, DUE (116kHz)
  */
+#include "ESP32_Adapter.h"
+
 #ifdef ARDUINO_ARCH_AVR // 125kHz
   typedef volatile uint8_t* fastio_reg;
   typedef uint8_t fastio_bm;


### PR DESCRIPTION
In case this is still useful to someone, it is rebased on the fork we are maintaining for quicker turnaround. It might need some additional work to also support the new TMC2240. Evaluate and have fun playing with TMC and ESP-IDF together!

Based on PR teemuatlut/TMCStepper#194 by @holgerpieta.

---
> Generally I prefer the original ESP-IDF instead of the Arduino framework, because it seems to me less magical and more predictable. So I tried to make this library compile in ESP-IDF without Arduino. Took much less work than I feared, which I guess shows again that this library is very well made. Thanks to everybody involved.
> 
> What I did not implement in ESP-IDF is the SPI interface, because I do not have any experience in that field and at first glance I wasn't able to match the Arduino SPI interface and the ESP-IDF API. Maybe someone with more experience can have a look at that. But then I'm not actually sure the hardware SPI is actually required, because the SW solution exists. To make sure nobody uses it accidentally (and to make it compile) I conditionally removed the affected constructors when ESP-IDF platform is configured.
> 
> I was able to test it on my ESP32 board with a TCM2208 stepper, but I neither have Arduino in place to try it nor any other stepper driver. So I would probably a good idea if someone with Arduino and other stepper drivers would test it before merging it upstream.
